### PR TITLE
Fix streaming-form-data installation to enable Moonraker startup

### DIFF
--- a/scripts/2_script_manual.sh
+++ b/scripts/2_script_manual.sh
@@ -77,7 +77,7 @@ echo " "
 echo "Installing moonraker dependencies..."
 opkg install python3-tornado python3-pillow python3-distro python3-curl python3-zeroconf python3-paho-mqtt python3-yaml python3-requests ip-full libsodium;
 
-pip install pyserial-asyncio lmdb streaming-form-data inotify-simple libnacl preprocess-cancellation apprise ldap3 dbus-next python-periphery importlib-metadata;
+pip install pyserial-asyncio lmdb streaming-form-data==1.17.0 inotify-simple libnacl preprocess-cancellation apprise ldap3 dbus-next python-periphery importlib-metadata;
 
 echo " "
 echo "   ###############"


### PR DESCRIPTION
This commit resolves the installation issue with the `streaming-form-data` package, ensuring that Moonraker can start successfully, as the package is a dependency for its operation.

Fixes #9